### PR TITLE
fix: request env permission for wayland detection

### DIFF
--- a/packages/winding/mod.ts
+++ b/packages/winding/mod.ts
@@ -24,7 +24,7 @@ export const load: LoadLibrary = () => {
   if (Deno.build.os === "windows") return Win32Load();
   // Prefer Wayland when WAYLAND_DISPLAY is set; fall back to X11 otherwise.
   if (
-    Deno.permissions.querySync({ name: "env", variable: "WAYLAND_DISPLAY" }).state === "granted" &&
+    Deno.permissions.requestSync({ name: "env", variable: "WAYLAND_DISPLAY" }).state === "granted" &&
     Deno.env.get("WAYLAND_DISPLAY")
   ) {
     return WaylandLoad();


### PR DESCRIPTION
## Summary

- Changes `Deno.permissions.querySync` to `Deno.permissions.requestSync` for the `WAYLAND_DISPLAY` env check in `packages/winding/mod.ts`
- `querySync` returns `"prompt"` (not `"granted"`) when the env permission hasn't been explicitly allowed (e.g. `deno run --allow-ffi`), causing the Wayland check to silently fail and fall back to X11/XWayland
- On Hyprland (Wayland), this makes the window completely uninteractable once it becomes floating

## Test plan

- [x] Confirmed the bug: `deno run --allow-ffi shapes.ts` on Hyprland → window becomes uninteractable when floating
- [x] Confirmed the fix: with `requestSync`, the native Wayland backend is correctly selected and the window works as expected

> [!NOTE]
> This change was authored by an LLM (Claude) and validated by a human on a Hyprland setup.