### PR TITLE
fix: scrolling

### DIFF
--- a/examples/scrolling.ts
+++ b/examples/scrolling.ts
@@ -1,0 +1,136 @@
+import { renderRawHTML } from "../packages/quox/mod.ts";
+
+const sections = Array.from({ length: 24 }, (_, index) => {
+  const sectionNumber = index + 1;
+  return `
+    <section>
+      <span class="eyebrow">Section ${sectionNumber.toString().padStart(2, "0")}</span>
+      <h2>Scrollable content block ${sectionNumber}</h2>
+      <p>
+        This page intentionally has much more content than the window can show at once.
+        Use the mouse wheel or trackpad to move through the rendered document.
+      </p>
+      <p>
+        Each block has enough text and spacing to make vertical scrolling easy to test,
+        including repainting, clipping, and layout continuity across the viewport edge.
+      </p>
+    </section>`;
+}).join("");
+
+const html = `
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      background: #f4f0e8;
+      color: #17202a;
+      font-family: Liberation Sans, Arial, sans-serif;
+      line-height: 1.5;
+    }
+
+    header {
+      padding: 40px 48px 28px;
+      background: #17202a;
+      color: #fbfaf7;
+      border-bottom: 8px solid #d7663b;
+    }
+
+    h1 {
+      margin: 0 0 12px;
+      font-size: 44px;
+      line-height: 1.05;
+    }
+
+    header p {
+      max-width: 680px;
+      margin: 0;
+      color: #d7e0e5;
+      font-size: 18px;
+    }
+
+    main {
+      width: 760px;
+      max-width: 100%;
+      padding: 28px 48px 72px;
+    }
+
+    section {
+      margin: 0 0 24px;
+      padding: 22px 24px;
+      background: #ffffff;
+      border: 1px solid #d7d0c3;
+      border-left: 8px solid #2f7d80;
+      border-radius: 6px;
+    }
+
+    section:nth-child(3n) {
+      border-left-color: #d7663b;
+    }
+
+    section:nth-child(4n) {
+      border-left-color: #6a65a8;
+    }
+
+    .eyebrow {
+      display: block;
+      margin-bottom: 8px;
+      color: #68717a;
+      font-size: 12px;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    h2 {
+      margin: 0 0 10px;
+      font-size: 24px;
+      line-height: 1.2;
+    }
+
+    p {
+      margin: 0 0 10px;
+      font-size: 16px;
+    }
+
+    p:last-child {
+      margin-bottom: 0;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Scrolling Demo</h1>
+    <p>
+      A deliberately long document for checking wheel input, viewport clipping,
+      and scroll position changes in the native window renderer.
+    </p>
+  </header>
+  <main>
+    ${sections}
+  </main>
+</body>
+</html>`;
+
+if (import.meta.main) {
+  const window = await renderRawHTML(html, { width: 760, height: 520 });
+
+  window.addEventListener((event) => {
+    switch (event.type) {
+      case "wheel":
+        console.log(`Scroll delta: (${event.deltaX}, ${event.deltaY})`);
+        break;
+      case "resize":
+        console.log(`Window resized to ${event.width}x${event.height}`);
+        break;
+      case "close":
+        console.log("Window closed");
+        break;
+    }
+  });
+}

--- a/packages/quox/mod.ts
+++ b/packages/quox/mod.ts
@@ -71,7 +71,7 @@ export class QuoxWindow implements Disposable {
   #width: number;
   #height: number;
   readonly #renderer: WasmRenderer;
-  #intervalId: number | null = null;
+  #intervalId: ReturnType<typeof setInterval> | null = null;
   #rendering = false;
   readonly #listeners: Array<(event: QuoxInputEvent) => void> = [];
 

--- a/packages/quox/src/lib.rs
+++ b/packages/quox/src/lib.rs
@@ -1,5 +1,5 @@
 use anyrender_vello::VelloScenePainter;
-use blitz_dom::{DocumentConfig, FontContext};
+use blitz_dom::{DocumentConfig, FontContext, Point};
 use blitz_html::HtmlDocument;
 use blitz_paint::paint_scene;
 use blitz_traits::net::DummyNetProvider;
@@ -141,6 +141,10 @@ impl QuoxRenderer {
         let content = doc.root_element().final_layout.size;
         self.scroll_x = self.scroll_x.min((content.width as u32).saturating_sub(w));
         self.scroll_y = self.scroll_y.min((content.height as u32).saturating_sub(h));
+        doc.set_viewport_scroll(Point {
+            x: self.scroll_x as f64,
+            y: self.scroll_y as f64,
+        });
 
         let device_handle = self.context.device_pool[self.dev_id].clone();
 
@@ -164,7 +168,7 @@ impl QuoxRenderer {
 
         let mut scene = Scene::new();
         let mut painter = VelloScenePainter::new(&mut scene);
-        paint_scene(&mut painter, &*doc, 1.0, w, h, self.scroll_x, self.scroll_y);
+        paint_scene(&mut painter, &*doc, 1.0, w, h, 0, 0);
 
         self.renderer
             .render_to_texture(


### PR DESCRIPTION
While testing scrolling [on wayland], I noticed 2 issues:
1. Scroll direction is wrong
2. Scroll "space allocation" is wrong: content is meant to be not scrollable to the top, and to be scrollable to the bottom until it ends, but currently it's reversed: I can scroll content_length upwards, and cannot scroll downwards at all.  

Summary:
1. This PR solves both of those issues by using proper blitz scroll utils.
2. This PR adds simple test with long content to be scrollable
3. This PR solves a tiny type error around timeouts