### PR TITLE
feat: window titles

### DIFF
--- a/examples/live_document.ts
+++ b/examples/live_document.ts
@@ -43,7 +43,7 @@ const head = `
     </style>
   `;
 
-const win = await openWindow({ width: 640, height: 360, head });
+const win = await openWindow({ width: 640, height: 360, title: "Live document", head });
 
 const main = win.document.createElement("main");
 const title = win.document.createElement("h1");
@@ -63,4 +63,5 @@ setInterval(() => {
   title.textContent = tick % 2 === 0 ? "Live document" : "Mutated document";
   title.setAttribute("class", tick % 2 === 0 ? "warm" : "cool");
   status.textContent = `Tick ${tick}`;
+  win.document.title = `Live document - tick ${tick}`;
 }, 700);

--- a/packages/quox/dom/document.ts
+++ b/packages/quox/dom/document.ts
@@ -2,18 +2,58 @@ import type { QuoxRenderer as WasmRenderer } from "../lib/quox.js";
 import { type AssertActive, attachDocumentInternals, type RequestRender } from "./internals.ts";
 import { QuoxElement, QuoxText } from "./node.ts";
 
+type SetNativeTitle = (title: string) => void;
+
 export class QuoxDocument {
   readonly #renderer: WasmRenderer;
+  readonly #requestRender: RequestRender;
   readonly #assertActive: AssertActive;
+  readonly #setNativeTitle: SetNativeTitle;
+  #currentTitle: string;
 
   constructor(
     renderer: WasmRenderer,
     requestRender: RequestRender,
     assertActive: AssertActive,
+    setNativeTitle: SetNativeTitle = () => undefined,
   ) {
     this.#renderer = renderer;
+    this.#requestRender = requestRender;
     this.#assertActive = assertActive;
-    attachDocumentInternals(this, { renderer, requestRender, assertActive });
+    this.#setNativeTitle = setNativeTitle;
+    this.#currentTitle = renderer.title();
+    attachDocumentInternals(this, {
+      renderer,
+      requestRender,
+      assertActive,
+      syncTitle: () => {
+        this.#syncTitle();
+      },
+    });
+  }
+
+  get title(): string {
+    return this.#syncTitle();
+  }
+
+  set title(value: string) {
+    this.#assertActive();
+    const title = String(value);
+    this.#renderer.set_title(title);
+    this.#currentTitle = title;
+    this.#setNativeTitle(title);
+    this.#requestRender();
+  }
+
+  #syncTitle(): string {
+    this.#assertActive();
+    const title = this.#renderer.title();
+    if (title !== this.#currentTitle) {
+      this.#currentTitle = title;
+      this.#setNativeTitle(title);
+    }
+
+    return title;
   }
 
   get documentElement(): QuoxElement {

--- a/packages/quox/dom/internals.ts
+++ b/packages/quox/dom/internals.ts
@@ -3,11 +3,13 @@ import type { QuoxDocument } from "./document.ts";
 
 export type RequestRender = () => void;
 export type AssertActive = () => void;
+export type SyncTitle = () => void;
 
 type DocumentInternals = {
   readonly renderer: WasmRenderer;
   readonly requestRender: RequestRender;
   readonly assertActive: AssertActive;
+  readonly syncTitle: SyncTitle;
 };
 
 const internals = new WeakMap<QuoxDocument, DocumentInternals>();

--- a/packages/quox/dom/mount_test.ts
+++ b/packages/quox/dom/mount_test.ts
@@ -16,6 +16,7 @@ class FakeRenderer {
   readonly operations: Operation[] = [];
   #nextNodeId = 1;
   readonly #text = new Map<number, string>();
+  #title = "";
 
   create_element(tagName: string): number {
     const id = this.#nextNodeId++;
@@ -40,6 +41,14 @@ class FakeRenderer {
 
   text_content(nodeId: number): string {
     return this.#text.get(nodeId) ?? "";
+  }
+
+  title(): string {
+    return this.#title;
+  }
+
+  set_title(value: string): void {
+    this.#title = value;
   }
 
   set_text_content(nodeId: number, value: string): void {
@@ -73,7 +82,7 @@ class FakeRenderer {
   }
 }
 
-function createTestDocument(): {
+function createTestDocument(setNativeTitle?: (title: string) => void): {
   document: QuoxDocument;
   renderer: FakeRenderer;
   root: QuoxElement;
@@ -84,6 +93,7 @@ function createTestDocument(): {
     renderer as unknown as WasmRenderer,
     noop,
     noop,
+    setNativeTitle,
   );
 
   return {
@@ -92,6 +102,39 @@ function createTestDocument(): {
     root: new QuoxElement(document, 0),
   };
 }
+
+Deno.test("document.title reads and writes the renderer title", () => {
+  const nativeTitles: string[] = [];
+  let renderCount = 0;
+  const renderer = new FakeRenderer();
+  const document = new QuoxDocument(
+    renderer as unknown as WasmRenderer,
+    () => {
+      renderCount += 1;
+    },
+    () => undefined,
+    (title) => nativeTitles.push(title),
+  );
+
+  assertEquals(document.title, "");
+
+  document.title = "Quox Notes";
+
+  assertEquals(document.title, "Quox Notes");
+  assertEquals(renderer.title(), "Quox Notes");
+  assertEquals(nativeTitles, ["Quox Notes"]);
+  assertEquals(renderCount, 1);
+});
+
+Deno.test("document title syncs to native title after DOM mutations", () => {
+  const nativeTitles: string[] = [];
+  const { document, renderer, root } = createTestDocument((title) => nativeTitles.push(title));
+
+  renderer.set_title("Changed elsewhere");
+  root.appendChild(document.createTextNode("trigger mutation"));
+
+  assertEquals(nativeTitles, ["Changed elsewhere"]);
+});
 
 Deno.test("mount walks fragments, function components, and nested arrays", async () => {
   const { renderer, root } = createTestDocument();

--- a/packages/quox/dom/node.ts
+++ b/packages/quox/dom/node.ts
@@ -14,8 +14,9 @@ export class QuoxNode {
   }
 
   set textContent(value: string | null) {
-    const { renderer, requestRender } = documentInternals(this.ownerDocument);
+    const { renderer, requestRender, syncTitle } = documentInternals(this.ownerDocument);
     renderer.set_text_content(this.nodeId, value ?? "");
+    syncTitle();
     requestRender();
   }
 
@@ -24,24 +25,27 @@ export class QuoxNode {
       throw new TypeError("node belongs to a different document");
     }
 
-    const { renderer, requestRender } = documentInternals(this.ownerDocument);
+    const { renderer, requestRender, syncTitle } = documentInternals(this.ownerDocument);
     renderer.append_child(this.nodeId, child.nodeId);
+    syncTitle();
     requestRender();
     return child;
   }
 
   remove(): void {
-    const { renderer, requestRender } = documentInternals(this.ownerDocument);
+    const { renderer, requestRender, syncTitle } = documentInternals(this.ownerDocument);
     renderer.remove_node(this.nodeId);
+    syncTitle();
     requestRender();
   }
 }
 
 export class QuoxElement extends QuoxNode {
   set innerHTML(value: QuoxInnerHTML) {
-    const { renderer, requestRender } = documentInternals(this.ownerDocument);
+    const { renderer, requestRender, syncTitle } = documentInternals(this.ownerDocument);
     const html = value;
     renderer.set_inner_html(this.nodeId, html);
+    syncTitle();
     requestRender();
   }
 

--- a/packages/quox/dom/window.ts
+++ b/packages/quox/dom/window.ts
@@ -32,12 +32,15 @@ export interface WindowOptions {
   width?: number;
   /** Height of the window in pixels (default 600). */
   height?: number;
+  /** Native window title. Overrides any initial `<title>` in `head`. */
+  title?: string;
   /** Initial content for `document.head`: an HTML string, or JSX from any recognized runtime. */
   head?: QuoxWindowContent;
   /** Initial content for `document.body`: an HTML string, or JSX from any recognized runtime. */
   body?: QuoxWindowContent;
 }
 
+const DEFAULT_WINDOW_TITLE = "quox";
 const BUTTON_INDEX: Record<"left" | "middle" | "right", number> = { left: 0, middle: 1, right: 2 };
 
 function contentToString(value: QuoxWindowContent | undefined): string {
@@ -102,6 +105,7 @@ export class QuoxWindow implements Disposable {
       renderer,
       () => this.#requestRender(),
       () => this.#assertActiveDocument(),
+      (title) => this.#win.setTitle(title),
     );
   }
 
@@ -120,6 +124,11 @@ export class QuoxWindow implements Disposable {
     try {
       await mountWindowContent(quoxWindow.document.head, options.head);
       await mountWindowContent(quoxWindow.document.body, options.body);
+      if (options.title !== undefined) {
+        quoxWindow.setTitle(options.title);
+      } else {
+        quoxWindow.#win.setTitle(quoxWindow.document.title || DEFAULT_WINDOW_TITLE);
+      }
     } catch (error) {
       quoxWindow[Symbol.dispose]();
       throw error;
@@ -226,6 +235,11 @@ export class QuoxWindow implements Disposable {
   removeEventListener(callback: (event: QuoxInputEvent) => void): void {
     const idx = this.#listeners.indexOf(callback);
     if (idx >= 0) this.#listeners.splice(idx, 1);
+  }
+
+  /** Set the native window title via `document.title`. */
+  setTitle(title: string): void {
+    this.document.title = title;
   }
 
   /** Stop the render loop and free WASM resources. */

--- a/packages/quox/src/lib.rs
+++ b/packages/quox/src/lib.rs
@@ -119,6 +119,28 @@ impl QuoxRendererState {
             })
             .ok_or_else(|| JsValue::from_str(&format!("Missing <{tag_name}> element")))
     }
+
+    fn optional_child_element_by_tag(
+        &self,
+        parent_id: usize,
+        tag_name: &str,
+    ) -> Result<Option<usize>, JsValue> {
+        let parent = self
+            .document
+            .get_node(parent_id)
+            .ok_or_else(|| invalid_node(parent_id))?;
+
+        Ok(parent.children.iter().find_map(|child_id| {
+            let child = self.document.get_node(*child_id)?;
+            let element = child.element_data()?;
+            (element.name.local.as_ref() == tag_name).then_some(*child_id)
+        }))
+    }
+
+    fn title_element(&self) -> Result<Option<usize>, JsValue> {
+        let head_id = self.child_element_by_tag(self.document.root_element().id, "head")?;
+        self.optional_child_element_by_tag(head_id, "title")
+    }
 }
 
 #[wasm_bindgen]
@@ -228,6 +250,19 @@ impl QuoxRenderer {
             .ok_or_else(|| invalid_node(node_id))
     }
 
+    /// Return the document title.
+    pub fn title(&self) -> Result<String, JsValue> {
+        let state = self.state.borrow();
+        match state.title_element()? {
+            Some(node_id) => state
+                .document
+                .get_node(node_id)
+                .map(|node| node.text_content())
+                .ok_or_else(|| invalid_node(node_id)),
+            None => Ok(String::new()),
+        }
+    }
+
     /// Set an element attribute.
     pub fn set_attribute(&self, node_id: usize, name: &str, value: &str) -> Result<(), JsValue> {
         let mut state = self.state.borrow_mut();
@@ -298,6 +333,29 @@ impl QuoxRenderer {
                     let text_id = mutator.create_text_node(value);
                     mutator.append_children(node_id, &[text_id]);
                 }
+            }
+
+            Ok(())
+        })
+    }
+
+    /// Replace the first document `<title>` text, creating the element in `<head>` if needed.
+    pub fn set_title(&self, value: &str) -> Result<(), JsValue> {
+        let mut state = self.state.borrow_mut();
+        let head_id = state.child_element_by_tag(state.document.root_element().id, "head")?;
+        let existing_title_id = state.optional_child_element_by_tag(head_id, "title")?;
+
+        state.mutate_document(|mutator| {
+            let title_id = existing_title_id.unwrap_or_else(|| {
+                let title_id = mutator.create_element(html_name("title"), Vec::new());
+                mutator.append_children(head_id, &[title_id]);
+                title_id
+            });
+
+            mutator.remove_and_drop_all_children(title_id);
+            if !value.is_empty() {
+                let text_id = mutator.create_text_node(value);
+                mutator.append_children(title_id, &[text_id]);
             }
 
             Ok(())

--- a/packages/winding/darwin.ts
+++ b/packages/winding/darwin.ts
@@ -202,6 +202,13 @@ class DarwinWindow implements Window {
     return this.#height;
   }
 
+  setTitle(title: string): void {
+    const { sel, send } = this.lib.ffi;
+    const titleString = makeNSString(this.lib.ffi, title);
+    send.void_id(this.nsWindow, sel("setTitle:"), titleString);
+    send.void(titleString, sel("release"));
+  }
+
   blit(rgba: Uint8Array, width: number, height: number): void {
     const { cf, cg, sel, send } = this.lib.ffi;
     this.#prevImageBuf = this.#imageBuf;

--- a/packages/winding/types.ts
+++ b/packages/winding/types.ts
@@ -35,6 +35,8 @@ export interface CloseEvent extends WindowEvent {
 export interface Window {
   [Symbol.dispose]: () => void;
   close(): void;
+  /** Set the native window title. */
+  setTitle(title: string): void;
   /** Blit (bit-block transfer) an RGBA pixel buffer to the window. Width and height must match the window dimensions. */
   blit(rgba: Uint8Array, width: number, height: number): void;
 }

--- a/packages/winding/wayland.ts
+++ b/packages/winding/wayland.ts
@@ -157,7 +157,7 @@ class WaylandWindow implements Window {
     this.#height = h;
 
     this.#setupListeners();
-    this.#setTitle("winding");
+    this.setTitle("winding");
 
     // Initial empty commit -- compositor will reply with configure
     sym.wl_proxy_marshal_array_flags(
@@ -226,7 +226,7 @@ class WaylandWindow implements Window {
     this.#configured = true;
   }
 
-  #setTitle(title: string): void {
+  setTitle(title: string): void {
     const sym = this.lib.wl.symbols;
     const titleBuf = cStr(title);
     sym.wl_proxy_marshal_array_flags(
@@ -237,6 +237,7 @@ class WaylandWindow implements Window {
       0,
       args(Deno.UnsafePointer.value(Deno.UnsafePointer.of(titleBuf))),
     );
+    sym.wl_display_flush(this.lib.display);
   }
 
   /**

--- a/packages/winding/win32.ts
+++ b/packages/winding/win32.ts
@@ -18,6 +18,14 @@ const UP_BUTTON: Partial<Record<WM, "left" | "middle" | "right">> = {
   [WM.RBUTTONUP]: "right",
 };
 
+function wideStringBuffer(value: string): ArrayBuffer {
+  const buffer = new ArrayBuffer((value.length + 1) * 2);
+  const view = new Uint16Array(buffer);
+  for (let i = 0; i < value.length; i++) view[i] = value.charCodeAt(i);
+  view[value.length] = 0;
+  return buffer;
+}
+
 class Win32Window implements Window {
   readonly id: bigint;
   readonly #hwnd: Deno.PointerObject;
@@ -43,6 +51,11 @@ class Win32Window implements Window {
     this.#hwnd = window;
     this.id = BigInt(Deno.UnsafePointer.value(window));
     lib.windows.set(this.id, this);
+  }
+
+  setTitle(title: string): void {
+    const ok = this.lib.user32.symbols.SetWindowTextW(this.#hwnd, wideStringBuffer(title));
+    if (!ok) throw new Error(this.lib.getLastError());
   }
 
   /**
@@ -111,14 +124,7 @@ class Win32Library implements Library {
   readonly gdi32: Deno.DynamicLibrary<typeof gdi32functions>;
   #wndClass = new ArrayBuffer(80);
   #classNameBuffer = (() => {
-    const name = "Winding";
-    const classNameBuffer = new ArrayBuffer((name.length + 1) * 2);
-    const classNameU16 = new Uint16Array(classNameBuffer);
-    for (let i = 0; i < name.length; i++) {
-      classNameU16[i] = name.charCodeAt(i);
-    }
-    classNameU16[name.length] = 0;
-    return classNameBuffer;
+    return wideStringBuffer("Winding");
   })();
   #wndProc: Deno.UnsafeCallback<{
     parameters: ["pointer", "u32", "usize", "usize"];

--- a/packages/winding/win32_ffi.ts
+++ b/packages/winding/win32_ffi.ts
@@ -32,6 +32,7 @@ export const user32functions = {
   ReleaseDC: { parameters: ["pointer", "pointer"], result: "i32" },
   SetCapture: { parameters: ["pointer"], result: "pointer" },
   ReleaseCapture: { parameters: [], result: "bool" },
+  SetWindowTextW: { parameters: ["pointer", "buffer"], result: "bool" },
   LoadCursorW: { parameters: ["pointer", "usize"], result: "usize" },
   RegisterClassExW: {
     parameters: ["buffer"],

--- a/packages/winding/x11.ts
+++ b/packages/winding/x11.ts
@@ -2,9 +2,11 @@ import type { Library, LoadLibrary, UIEvent, Window } from "./src/../types.ts";
 import { x11functions, XEventMask, XEventType } from "./x11_ffi.ts";
 
 function cString(s: string): Uint8Array<ArrayBuffer> {
-  const buf = new Uint8Array(s.length + 1) as Uint8Array<ArrayBuffer>;
-  for (let i = 0; i < s.length; i++) buf[i] = s.charCodeAt(i);
-  return buf;
+  return new TextEncoder().encode(`${s}\0`);
+}
+
+function utf8Bytes(s: string): Uint8Array<ArrayBuffer> {
+  return new TextEncoder().encode(s);
 }
 
 // All event masks except:
@@ -86,6 +88,23 @@ class X11Window implements Window {
     lib.windows.set(this.id, this);
   }
 
+  setTitle(title: string): void {
+    const titleBytes = utf8Bytes(title);
+    const titleBuffer = titleBytes.length > 0 ? titleBytes : new Uint8Array(1);
+    this.lib.X11.symbols.XChangeProperty(
+      this.lib.display,
+      this.id,
+      this.lib.netWmName,
+      this.lib.utf8String,
+      8,
+      0,
+      titleBuffer,
+      titleBytes.length,
+    );
+    this.lib.X11.symbols.XStoreName(this.lib.display, this.id, cString(title));
+    this.lib.X11.symbols.XFlush(this.lib.display);
+  }
+
   /**
    * Copy an RGBA pixel buffer to the X11 window. The buffer must be
    * `width * height * 4` bytes. Internally converts to X11 TrueColor BGRX
@@ -156,6 +175,8 @@ class X11Library implements Library {
   readonly windows = new Map<bigint, X11Window>();
   readonly wmProtocols: bigint;
   readonly wmDeleteWindow: bigint;
+  readonly netWmName: bigint;
+  readonly utf8String: bigint;
   constructor() {
     this.X11 = Deno.dlopen("libX11.so", x11functions);
     const display = this.X11.symbols.XOpenDisplay(null);
@@ -168,6 +189,8 @@ class X11Library implements Library {
     this.wmDeleteWindow = BigInt(
       this.X11.symbols.XInternAtom(display, cString("WM_DELETE_WINDOW"), 0),
     );
+    this.netWmName = BigInt(this.X11.symbols.XInternAtom(display, cString("_NET_WM_NAME"), 0));
+    this.utf8String = BigInt(this.X11.symbols.XInternAtom(display, cString("UTF8_STRING"), 0));
   }
   openWindow(x = 0, y = 0, w = 800, h = 600): X11Window {
     return new X11Window(this, x, y, w, h);


### PR DESCRIPTION
Adds support for window titles:

```ts
// Set the initial native window title with an option.
const win = await openWindow({ title: "My App", body: "<h1>Hello</h1>" });

// Set the canonical document title.
win.document.title = "My App";

// Use the window convenience alias.
win.setTitle("My App");

// Set the initial title through an HTML head string.
const winFromHeadString = await openWindow({ head: "<title>My App</title>", body: "<h1>Hello</h1>" });

// Set the initial title through JSX head content.
const winFromJsxHead = await openWindow({ head: <title>My App</title>, body: <App /> });

// Mutate the live head title element.
win.document.head.appendChild(win.document.createElement("title")).textContent = "My App";
```
Closes #25.