### PR TITLE
fix: route the default window title through document.title

### DIFF
--- a/packages/quox/dom/window.ts
+++ b/packages/quox/dom/window.ts
@@ -124,11 +124,7 @@ export class QuoxWindow implements Disposable {
     try {
       await mountWindowContent(quoxWindow.document.head, options.head);
       await mountWindowContent(quoxWindow.document.body, options.body);
-      if (options.title !== undefined) {
-        quoxWindow.setTitle(options.title);
-      } else {
-        quoxWindow.#win.setTitle(quoxWindow.document.title || DEFAULT_WINDOW_TITLE);
-      }
+      quoxWindow.setTitle(options.title ?? (quoxWindow.document.title || DEFAULT_WINDOW_TITLE));
     } catch (error) {
       quoxWindow[Symbol.dispose]();
       throw error;


### PR DESCRIPTION
The no-explicit-title fallback in QuoxWindow.create called this.#win.setTitle() directly, bypassing the document.title setter. A window opened without a title option (and no <title> in head) would show "quox" in the OS chrome while document.title stayed "" forever, since no <title> element was ever created and no cached state was updated to match. Route both branches through setTitle()/document.title so the DOM and the native window agree.