### PR TITLE
refactor(winding): share UTF-8 string-encoding helpers across backends

### DIFF
--- a/packages/winding/darwin_ffi.ts
+++ b/packages/winding/darwin_ffi.ts
@@ -5,11 +5,9 @@
 // requires a fixed parameter/result shape per symbol, so the Darwin backend
 // opens `libobjc` once per distinct call shape and shares those handles.
 
-export function cStr(s: string): Uint8Array<ArrayBuffer> {
-  const buf = new Uint8Array(s.length + 1) as Uint8Array<ArrayBuffer>;
-  for (let i = 0; i < s.length; i++) buf[i] = s.charCodeAt(i);
-  return buf;
-}
+// `initWithUTF8String:` and friends require genuine UTF-8 bytes.
+import { utf8CString as cStr } from "./text_encoding.ts";
+export { cStr };
 
 export const LIBOBJC = "/usr/lib/libobjc.dylib";
 export const APPKIT = "/System/Library/Frameworks/AppKit.framework/AppKit";

--- a/packages/winding/text_encoding.ts
+++ b/packages/winding/text_encoding.ts
@@ -1,0 +1,9 @@
+/** Encode a string as null-terminated UTF-8 bytes, suitable for C-string FFI parameters. */
+export function utf8CString(s: string): Uint8Array<ArrayBuffer> {
+  return new TextEncoder().encode(`${s}\0`);
+}
+
+/** Encode a string as UTF-8 bytes without a null terminator, for length-prefixed FFI parameters. */
+export function utf8Bytes(s: string): Uint8Array<ArrayBuffer> {
+  return new TextEncoder().encode(s);
+}

--- a/packages/winding/wayland.ts
+++ b/packages/winding/wayland.ts
@@ -8,6 +8,7 @@ import {
   WlSeatCap,
   WlShmFormat,
 } from "./wayland_ffi.ts";
+import { utf8CString as cStr } from "./text_encoding.ts";
 
 // ---------------------------------------------------------------------------
 // libc helpers (memfd, mmap, poll) — needed for shared-memory pixel buffers
@@ -34,12 +35,6 @@ const POLLIN = 1;
 const RTLD_NOW = 0x2;
 const RTLD_NOLOAD = 0x4;
 const LIBWAYLAND_CLIENT_SO = "libwayland-client.so.0";
-
-function cStr(s: string): Uint8Array<ArrayBuffer> {
-  const b = new Uint8Array(s.length + 1);
-  for (let i = 0; i < s.length; i++) b[i] = s.charCodeAt(i);
-  return b;
-}
 
 function dlsymRequired(
   libdl: Deno.DynamicLibrary<typeof libdlSymbols>,

--- a/packages/winding/x11.ts
+++ b/packages/winding/x11.ts
@@ -1,13 +1,6 @@
 import type { Library, LoadLibrary, UIEvent, Window } from "./src/../types.ts";
 import { x11functions, XEventMask, XEventType } from "./x11_ffi.ts";
-
-function cString(s: string): Uint8Array<ArrayBuffer> {
-  return new TextEncoder().encode(`${s}\0`);
-}
-
-function utf8Bytes(s: string): Uint8Array<ArrayBuffer> {
-  return new TextEncoder().encode(s);
-}
+import { utf8Bytes, utf8CString as cString } from "./text_encoding.ts";
 
 // All event masks except:
 //   - PointerMotionHintMask (bit 7): throttles MotionNotify to one hint per entry


### PR DESCRIPTION
x11.ts, darwin_ffi.ts, and wayland.ts each carried their own implementation of "encode a string as a null-terminated C-string buffer" — x11's used TextEncoder (correct UTF-8), while darwin's and wayland's used a charCodeAt loop that truncates multi-byte characters, silently mis-encoding non-ASCII strings passed to initWithUTF8String: and the Wayland wire protocol (both of which expect real UTF-8). Consolidate on one correct implementation in text_encoding.ts so a future encoding fix only has to happen once.

No behavior change for the existing ASCII-only call sites (class names, selectors, atom names, interface names).