### PR TITLE
perf: sync the native title once per render instead of per mutation

### DIFF
--- a/packages/quox/dom/document.ts
+++ b/packages/quox/dom/document.ts
@@ -9,7 +9,7 @@ export class QuoxDocument {
   readonly #requestRender: RequestRender;
   readonly #assertActive: AssertActive;
   readonly #setNativeTitle: SetNativeTitle;
-  #currentTitle: string;
+  #lastNativeTitle: string;
 
   constructor(
     renderer: WasmRenderer,
@@ -21,39 +21,37 @@ export class QuoxDocument {
     this.#requestRender = requestRender;
     this.#assertActive = assertActive;
     this.#setNativeTitle = setNativeTitle;
-    this.#currentTitle = renderer.title();
-    attachDocumentInternals(this, {
-      renderer,
-      requestRender,
-      assertActive,
-      syncTitle: () => {
-        this.#syncTitle();
-      },
-    });
+    this.#lastNativeTitle = renderer.title();
+    attachDocumentInternals(this, { renderer, requestRender, assertActive });
   }
 
   get title(): string {
-    return this.#syncTitle();
+    this.#assertActive();
+    return this.#renderer.title();
   }
 
   set title(value: string) {
     this.#assertActive();
     const title = String(value);
     this.#renderer.set_title(title);
-    this.#currentTitle = title;
+    this.#lastNativeTitle = title;
     this.#setNativeTitle(title);
     this.#requestRender();
   }
 
-  #syncTitle(): string {
+  /**
+   * Push the live `<title>` text to the native window if it changed since the last push. Called
+   * once per render pass so title-affecting DOM edits (e.g. appending a `<title>` element, or
+   * editing one via `textContent`/`innerHTML`) reach the OS without every DOM mutation in the
+   * document paying for a `<head>` lookup.
+   */
+  syncNativeTitle(): void {
     this.#assertActive();
     const title = this.#renderer.title();
-    if (title !== this.#currentTitle) {
-      this.#currentTitle = title;
+    if (title !== this.#lastNativeTitle) {
+      this.#lastNativeTitle = title;
       this.#setNativeTitle(title);
     }
-
-    return title;
   }
 
   get documentElement(): QuoxElement {

--- a/packages/quox/dom/internals.ts
+++ b/packages/quox/dom/internals.ts
@@ -3,13 +3,11 @@ import type { QuoxDocument } from "./document.ts";
 
 export type RequestRender = () => void;
 export type AssertActive = () => void;
-export type SyncTitle = () => void;
 
 type DocumentInternals = {
   readonly renderer: WasmRenderer;
   readonly requestRender: RequestRender;
   readonly assertActive: AssertActive;
-  readonly syncTitle: SyncTitle;
 };
 
 const internals = new WeakMap<QuoxDocument, DocumentInternals>();

--- a/packages/quox/dom/mount_test.ts
+++ b/packages/quox/dom/mount_test.ts
@@ -126,13 +126,26 @@ Deno.test("document.title reads and writes the renderer title", () => {
   assertEquals(renderCount, 1);
 });
 
-Deno.test("document title syncs to native title after DOM mutations", () => {
+Deno.test("document.title reads live renderer state without side effects", () => {
   const nativeTitles: string[] = [];
-  const { document, renderer, root } = createTestDocument((title) => nativeTitles.push(title));
+  const { document, renderer } = createTestDocument((title) => nativeTitles.push(title));
 
   renderer.set_title("Changed elsewhere");
-  root.appendChild(document.createTextNode("trigger mutation"));
 
+  assertEquals(document.title, "Changed elsewhere");
+  assertEquals(nativeTitles, []);
+});
+
+Deno.test("syncNativeTitle pushes title changes made via generic DOM mutation", () => {
+  const nativeTitles: string[] = [];
+  const { document, renderer } = createTestDocument((title) => nativeTitles.push(title));
+
+  renderer.set_title("Changed elsewhere");
+  document.syncNativeTitle();
+
+  assertEquals(nativeTitles, ["Changed elsewhere"]);
+
+  document.syncNativeTitle();
   assertEquals(nativeTitles, ["Changed elsewhere"]);
 });
 

--- a/packages/quox/dom/node.ts
+++ b/packages/quox/dom/node.ts
@@ -14,9 +14,8 @@ export class QuoxNode {
   }
 
   set textContent(value: string | null) {
-    const { renderer, requestRender, syncTitle } = documentInternals(this.ownerDocument);
+    const { renderer, requestRender } = documentInternals(this.ownerDocument);
     renderer.set_text_content(this.nodeId, value ?? "");
-    syncTitle();
     requestRender();
   }
 
@@ -25,27 +24,24 @@ export class QuoxNode {
       throw new TypeError("node belongs to a different document");
     }
 
-    const { renderer, requestRender, syncTitle } = documentInternals(this.ownerDocument);
+    const { renderer, requestRender } = documentInternals(this.ownerDocument);
     renderer.append_child(this.nodeId, child.nodeId);
-    syncTitle();
     requestRender();
     return child;
   }
 
   remove(): void {
-    const { renderer, requestRender, syncTitle } = documentInternals(this.ownerDocument);
+    const { renderer, requestRender } = documentInternals(this.ownerDocument);
     renderer.remove_node(this.nodeId);
-    syncTitle();
     requestRender();
   }
 }
 
 export class QuoxElement extends QuoxNode {
   set innerHTML(value: QuoxInnerHTML) {
-    const { renderer, requestRender, syncTitle } = documentInternals(this.ownerDocument);
+    const { renderer, requestRender } = documentInternals(this.ownerDocument);
     const html = value;
     renderer.set_inner_html(this.nodeId, html);
-    syncTitle();
     requestRender();
   }
 

--- a/packages/quox/dom/window.ts
+++ b/packages/quox/dom/window.ts
@@ -211,6 +211,8 @@ export class QuoxWindow implements Disposable {
     const renderWidth = this.#width;
     const renderHeight = this.#height;
     try {
+      this.document.syncNativeTitle();
+
       // Render the retained Blitz document via WebGPU in WASM.
       const rgba = await this.#renderer.render();
 


### PR DESCRIPTION
syncTitle() was called from every appendChild/remove/textContent/innerHTML across the whole document (not just <head>), so any DOM write anywhere — including deep in <body>, on a totally unrelated node — paid for a root->head->title wasm round trip just to check whether the title happened to change. It also made document.title's getter impure (a plain read could trigger a native FFI call), and caused a redundant duplicate native setTitle call whenever the initial title came from <head> content.

Replace the per-mutation hook with QuoxDocument#syncNativeTitle(), called once per actual render pass from QuoxWindow's render loop. This still catches title changes made through generic DOM mutation (creating a <title> element, editing one via textContent/innerHTML, appending it to head from JSX or an HTML string) since a render always follows shortly after any mutation, but collapses a burst of unrelated mutations before a paint into a single check instead of one per mutation. document.title's getter goes back to being a pure passthrough read.