### PR TITLE
feat: permit passing window body directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ quox already works as a hello world example. Paste the following code to `main.t
 /** @jsxImportSource jsr:@quoxlabs/jsx */
 import { openWindow } from "jsr:@quoxlabs/quox";
 
-await openWindow({ body: <h1>Hello, world!</h1> });
+await openWindow(<h1>Hello, world!</h1>);
 ```
 
 Running

--- a/examples/hello_world.ts
+++ b/examples/hello_world.ts
@@ -5,5 +5,5 @@ const body = `
 <p>Meow!</p>`;
 
 if (import.meta.main) {
-  await openWindow({ body });
+  await openWindow(body);
 }

--- a/packages/quox/dom/mount.ts
+++ b/packages/quox/dom/mount.ts
@@ -69,6 +69,11 @@ async function createNodes(document: QuoxDocument, value: unknown): Promise<Quox
  * Recognize a vnode produced by any supported JSX runtime and normalize it to a common shape.
  * Add a branch here to support another runtime.
  */
+/** True if `value` looks like a vnode from any JSX runtime `mount` recognizes (see `normalizeVNode`). */
+export function isVNode(value: unknown): boolean {
+  return typeof value === "object" && value !== null && !Array.isArray(value) && normalizeVNode(value) !== null;
+}
+
 function normalizeVNode(value: object): NormalizedVNode | null {
   if (isQuoxLikeVNode(value)) {
     return { type: value.type, props: value.props, children: value.children };

--- a/packages/quox/dom/window.ts
+++ b/packages/quox/dom/window.ts
@@ -3,7 +3,7 @@ import { QuoxRenderer as WasmRenderer } from "../lib/quox.js";
 import { load as windingLoad } from "@quoxlabs/winding";
 import type { Library as WindingLibrary, UIEvent as WindingUIEvent, Window as WindingWindow } from "@quoxlabs/winding";
 import { QuoxDocument } from "./document.ts";
-import { mount, type QuoxRenderable } from "./mount.ts";
+import { isVNode, mount, type QuoxRenderable } from "./mount.ts";
 import type { QuoxElement, QuoxInnerHTML } from "./node.ts";
 
 export type QuoxInputEvent =
@@ -42,6 +42,13 @@ export interface WindowOptions {
 
 const DEFAULT_WINDOW_TITLE = "quox";
 const BUTTON_INDEX: Record<"left" | "middle" | "right", number> = { left: 0, middle: 1, right: 2 };
+
+/** Anything that isn't itself renderable content (a string, array, or vnode) is an options bag. */
+function isWindowOptions(value: QuoxWindowContent | WindowOptions | undefined): value is WindowOptions {
+  if (value === undefined) return true;
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  return !isVNode(value);
+}
 
 function contentToString(value: QuoxWindowContent | undefined): string {
   return typeof value === "string" ? value : "";
@@ -270,8 +277,12 @@ export class QuoxWindow implements Disposable {
 
 /**
  * Open a blank native window with a live DOM facade backed by Blitz's WASM document mutator.
+ *
+ * Accepts either a `WindowOptions` bag, or content (an HTML string or JSX) as shorthand for
+ * `{ body: content }`.
  */
-export async function openWindow(options?: WindowOptions): Promise<QuoxWindow> {
+export async function openWindow(arg?: QuoxWindowContent | WindowOptions): Promise<QuoxWindow> {
+  const options = isWindowOptions(arg) ? arg : { body: arg };
   const win = await QuoxWindow.create(options);
   win.start();
   return win;

--- a/packages/quox/mod.ts
+++ b/packages/quox/mod.ts
@@ -7,6 +7,6 @@ export * from "./dom/node.ts";
 export * from "./dom/window.ts";
 
 if (import.meta.main) {
-  const win = await openWindow({ body: "<h1>Hello from Blitz WASM</h1>" });
+  const win = await openWindow("<h1>Hello from Blitz WASM</h1>");
   console.log("Window open:", win);
 }


### PR DESCRIPTION
Before:

```tsx
await openWindow({ body: <h1>Hello, world!</h1> });
```

After:

```tsx
await openWindow(<h1>Hello, world!</h1>);
```