### PR TITLE
feat: `document.nodeFromPoint`

### DIFF
--- a/examples/input_handling.ts
+++ b/examples/input_handling.ts
@@ -21,11 +21,13 @@ if (import.meta.main) {
 
   window.addEventListener((event) => {
     switch (event.type) {
-      case "mousemove":
+      case "mousemove": {
+        const hit = window.document.nodeFromPoint(event.x, event.y);
         console.log(
-          `Mouse moved to (${event.x.toFixed(1)}, ${event.y.toFixed(1)})`,
+          `Mouse moved to (${event.x.toFixed(1)}, ${event.y.toFixed(1)}); hit node: ${hit?.nodeId ?? "none"}`,
         );
         break;
+      }
       case "mousedown":
       case "mouseup":
         console.log(

--- a/packages/quox/dom/document.ts
+++ b/packages/quox/dom/document.ts
@@ -1,6 +1,6 @@
 import type { QuoxRenderer as WasmRenderer } from "../lib/quox.js";
 import { type AssertActive, attachDocumentInternals, type RequestRender } from "./internals.ts";
-import { QuoxElement, QuoxText } from "./node.ts";
+import { QuoxElement, QuoxNode, QuoxText } from "./node.ts";
 
 type SetNativeTitle = (title: string) => void;
 
@@ -67,6 +67,17 @@ export class QuoxDocument {
   get body(): QuoxElement {
     this.#assertActive();
     return new QuoxElement(this, this.#renderer.body());
+  }
+
+  /**
+   * Return the DOM node at the given viewport-pixel coordinates (the same coordinate
+   * space `mousemove` events use), or `null` if nothing is there. Does not distinguish
+   * element vs. text hits.
+   */
+  nodeFromPoint(x: number, y: number): QuoxNode | null {
+    this.#assertActive();
+    const nodeId = this.#renderer.node_from_point(x, y);
+    return nodeId === undefined ? null : new QuoxNode(this, nodeId);
   }
 
   createElement(tagName: string): QuoxElement {

--- a/packages/quox/dom/mount_test.ts
+++ b/packages/quox/dom/mount_test.ts
@@ -82,15 +82,19 @@ class FakeRenderer {
   }
 
   #hitNodeId: number | undefined = undefined;
+  #lastHitPoint: { x: number; y: number } | undefined;
 
   node_from_point(x: number, y: number): number | undefined {
-    void x;
-    void y;
+    this.#lastHitPoint = { x, y };
     return this.#hitNodeId;
   }
 
   setHitNodeId(id: number | undefined): void {
     this.#hitNodeId = id;
+  }
+
+  get lastHitPoint(): { x: number; y: number } | undefined {
+    return this.#lastHitPoint;
   }
 }
 
@@ -410,4 +414,13 @@ Deno.test("document.nodeFromPoint wraps the hit node id", () => {
 
   assert(hit instanceof QuoxNode);
   assertEquals(hit?.nodeId, 5);
+});
+
+Deno.test("document.nodeFromPoint forwards coordinates unchanged", () => {
+  const { document, renderer } = createTestDocument();
+  renderer.setHitNodeId(5);
+
+  document.nodeFromPoint(12.5, 34.5);
+
+  assertEquals(renderer.lastHitPoint, { x: 12.5, y: 34.5 });
 });

--- a/packages/quox/dom/mount_test.ts
+++ b/packages/quox/dom/mount_test.ts
@@ -4,7 +4,7 @@ import type { QuoxRenderer as WasmRenderer } from "../lib/quox.js";
 import { QuoxDocument } from "./document.ts";
 import { getElementFunctionProps } from "./handlers.ts";
 import { mount } from "./mount.ts";
-import { QuoxElement } from "./node.ts";
+import { QuoxElement, QuoxNode } from "./node.ts";
 
 type Operation =
   | { type: "create_element"; id: number; tagName: string }
@@ -79,6 +79,18 @@ class FakeRenderer {
   remove_attribute(nodeId: number, name: string): void {
     void nodeId;
     void name;
+  }
+
+  #hitNodeId: number | undefined = undefined;
+
+  node_from_point(x: number, y: number): number | undefined {
+    void x;
+    void y;
+    return this.#hitNodeId;
+  }
+
+  setHitNodeId(id: number | undefined): void {
+    this.#hitNodeId = id;
   }
 }
 
@@ -381,4 +393,21 @@ Deno.test("mount resolves Preact-shaped fragments and function components withou
     { type: "append_child", parentId: 0, childId: 1 },
     { type: "append_child", parentId: 0, childId: 3 },
   ]);
+});
+
+Deno.test("document.nodeFromPoint returns null when nothing is hit", () => {
+  const { document, renderer } = createTestDocument();
+  renderer.setHitNodeId(undefined);
+
+  assertEquals(document.nodeFromPoint(10, 20), null);
+});
+
+Deno.test("document.nodeFromPoint wraps the hit node id", () => {
+  const { document, renderer } = createTestDocument();
+  renderer.setHitNodeId(5);
+
+  const hit = document.nodeFromPoint(10, 20);
+
+  assert(hit instanceof QuoxNode);
+  assertEquals(hit?.nodeId, 5);
 });

--- a/packages/quox/src/lib.rs
+++ b/packages/quox/src/lib.rs
@@ -141,7 +141,8 @@ impl QuoxRendererState {
     /// missing `<head>` (e.g. after `document.head.remove()`) by returning `None` rather than
     /// failing, so title lookups never break unrelated DOM operations.
     fn title_element(&self) -> Result<Option<usize>, JsValue> {
-        let Some(head_id) = self.optional_child_element_by_tag(self.document.root_element().id, "head")?
+        let Some(head_id) =
+            self.optional_child_element_by_tag(self.document.root_element().id, "head")?
         else {
             return Ok(None);
         };
@@ -223,6 +224,16 @@ impl QuoxRenderer {
         let mut state = self.state.borrow_mut();
         state.scroll_x = state.scroll_x.saturating_add_signed(delta_x);
         state.scroll_y = state.scroll_y.saturating_add_signed(delta_y);
+    }
+
+    /// Return the id of the topmost DOM node at the given viewport-pixel coordinates
+    /// (top-left origin, unscaled — the same space `mousemove` events report), or `None`
+    /// if nothing is hit (e.g. before the first `render()`, or the point is outside the
+    /// document). Delegates to Blitz's own hit-testing, which already accounts for
+    /// per-node scroll offsets and stacking-context/z-index ordering.
+    pub fn node_from_point(&self, x: f32, y: f32) -> Option<usize> {
+        let state = self.state.borrow();
+        state.document.hit(x, y).map(|hit| hit.node_id)
     }
 
     /// Remove a node from the retained document.
@@ -350,7 +361,8 @@ impl QuoxRenderer {
     /// `document.head.remove()`), this is a no-op rather than an error.
     pub fn set_title(&self, value: &str) -> Result<(), JsValue> {
         let mut state = self.state.borrow_mut();
-        let Some(head_id) = state.optional_child_element_by_tag(state.document.root_element().id, "head")?
+        let Some(head_id) =
+            state.optional_child_element_by_tag(state.document.root_element().id, "head")?
         else {
             return Ok(());
         };

--- a/packages/quox/src/lib.rs
+++ b/packages/quox/src/lib.rs
@@ -49,6 +49,65 @@ fn invalid_element(node_id: usize) -> JsValue {
     JsValue::from_str(&format!("DOM node id is not an element: {node_id}"))
 }
 
+/// Convert viewport-pixel coordinates (the space `mousemove` events report) into Blitz's
+/// page-space coordinates (viewport coordinates plus the current scroll offset), or
+/// `None` if the point is non-finite or outside the viewport bounds.
+fn viewport_point_to_page(
+    x: f32,
+    y: f32,
+    width: u32,
+    height: u32,
+    scroll_x: u32,
+    scroll_y: u32,
+) -> Option<(f32, f32)> {
+    if !x.is_finite() || !y.is_finite() {
+        return None;
+    }
+    if x < 0.0 || y < 0.0 || x >= width as f32 || y >= height as f32 {
+        return None;
+    }
+
+    Some((x + scroll_x as f32, y + scroll_y as f32))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::viewport_point_to_page;
+
+    #[test]
+    fn rejects_non_finite_coordinates() {
+        assert_eq!(viewport_point_to_page(f32::NAN, 10.0, 800, 600, 0, 0), None);
+        assert_eq!(
+            viewport_point_to_page(10.0, f32::INFINITY, 800, 600, 0, 0),
+            None
+        );
+    }
+
+    #[test]
+    fn rejects_out_of_viewport_coordinates() {
+        assert_eq!(viewport_point_to_page(-1.0, 10.0, 800, 600, 0, 0), None);
+        assert_eq!(viewport_point_to_page(10.0, -1.0, 800, 600, 0, 0), None);
+        assert_eq!(viewport_point_to_page(800.0, 10.0, 800, 600, 0, 0), None);
+        assert_eq!(viewport_point_to_page(10.0, 600.0, 800, 600, 0, 0), None);
+    }
+
+    #[test]
+    fn passes_through_unscrolled_coordinates() {
+        assert_eq!(
+            viewport_point_to_page(10.0, 20.0, 800, 600, 0, 0),
+            Some((10.0, 20.0))
+        );
+    }
+
+    #[test]
+    fn adds_scroll_offset_to_reach_page_coordinates() {
+        assert_eq!(
+            viewport_point_to_page(10.0, 20.0, 800, 600, 50, 100),
+            Some((60.0, 120.0))
+        );
+    }
+}
+
 #[wasm_bindgen(start)]
 pub fn start() {
     console_error_panic_hook::set_once();
@@ -148,6 +207,33 @@ impl QuoxRendererState {
         };
         self.optional_child_element_by_tag(head_id, "title")
     }
+
+    /// Resolve layout for the current viewport/scroll state. Shared by `render()` and
+    /// `node_from_point()` so hit-testing never sees stale geometry — mirrors how browsers
+    /// force a layout flush before geometry queries like `elementFromPoint`.
+    fn sync_layout(&mut self) {
+        self.document.set_viewport(Viewport::new(
+            self.width,
+            self.height,
+            1.0,
+            ColorScheme::Light,
+        ));
+        self.document.resolve(0.0);
+
+        // Clamp scroll offsets to the laid-out content size so the viewport
+        // can never scroll past the end of the document.
+        let content = self.document.root_element().final_layout.size;
+        self.scroll_x = self
+            .scroll_x
+            .min((content.width as u32).saturating_sub(self.width));
+        self.scroll_y = self
+            .scroll_y
+            .min((content.height as u32).saturating_sub(self.height));
+        self.document.set_viewport_scroll(Point {
+            x: self.scroll_x as f64,
+            y: self.scroll_y as f64,
+        });
+    }
 }
 
 #[wasm_bindgen]
@@ -228,12 +314,23 @@ impl QuoxRenderer {
 
     /// Return the id of the topmost DOM node at the given viewport-pixel coordinates
     /// (top-left origin, unscaled — the same space `mousemove` events report), or `None`
-    /// if nothing is hit (e.g. before the first `render()`, or the point is outside the
-    /// document). Delegates to Blitz's own hit-testing, which already accounts for
-    /// per-node scroll offsets and stacking-context/z-index ordering.
+    /// if nothing is hit (e.g. the point is outside the viewport, or nothing is there).
+    /// Forces a layout resolve first, then delegates to Blitz's own hit-testing — which
+    /// still has a known TODO for z-index disambiguation among plain overlapping siblings
+    /// (see Blitz's `Node::hit`), so overlapping-sibling ordering isn't fully guaranteed.
     pub fn node_from_point(&self, x: f32, y: f32) -> Option<usize> {
-        let state = self.state.borrow();
-        state.document.hit(x, y).map(|hit| hit.node_id)
+        let mut state = self.state.borrow_mut();
+        state.sync_layout();
+
+        let (page_x, page_y) = viewport_point_to_page(
+            x,
+            y,
+            state.width,
+            state.height,
+            state.scroll_x,
+            state.scroll_y,
+        )?;
+        state.document.hit(page_x, page_y).map(|hit| hit.node_id)
     }
 
     /// Remove a node from the retained document.
@@ -402,27 +499,9 @@ impl QuoxRenderer {
     pub async fn render(&self) -> Result<Vec<u8>, JsValue> {
         let (_texture, gpu_buffer, row_bytes, padded_row_bytes, w, h) = {
             let mut state = self.state.borrow_mut();
+            state.sync_layout();
             let w = state.width;
             let h = state.height;
-
-            state
-                .document
-                .set_viewport(Viewport::new(w, h, 1.0, ColorScheme::Light));
-            state.document.resolve(0.0);
-
-            // Clamp scroll offsets to the laid-out content size so the viewport
-            // can never scroll past the end of the document.
-            let content = state.document.root_element().final_layout.size;
-            state.scroll_x = state.scroll_x.min((content.width as u32).saturating_sub(w));
-            state.scroll_y = state
-                .scroll_y
-                .min((content.height as u32).saturating_sub(h));
-            let scroll_x = state.scroll_x;
-            let scroll_y = state.scroll_y;
-            state.document.set_viewport_scroll(Point {
-                x: scroll_x as f64,
-                y: scroll_y as f64,
-            });
 
             let device_handle = state.context.device_pool[state.dev_id].clone();
 


### PR DESCRIPTION
Adds basic hit testing (translating screen coordinates to node identifiers).

Towards #16.